### PR TITLE
Fixed running check

### DIFF
--- a/eventloop.lua
+++ b/eventloop.lua
@@ -117,8 +117,8 @@ local EventLoop = {
 		if fn then
 			self:timeout(0, fn)
 		end
-		private.running = private.loop
 		if not self:running() then
+			private.running = private.loop
 			while true do
 				if #private.eventListeners > 0 then
 					local event


### PR DESCRIPTION
This API unfortunately doesn't work at all, it just exits immediately! It appears this is because of commit 95caa4b, which changed the way `running` is determined.

At https://github.com/Ferdi265/ComputerCraft-EventLoop/blob/master/eventloop.lua#L120 which is the entry point in `run` you set `private.running` to `private.loop` which is a non-nil table. In the next line you check `if not self:running() then`, however **this check will always return false**, because `running` does `return private.running`, which will always return the non-nil table, e.g. `true`. So the loop can never start.

This change simply moves that assignment after the check.
